### PR TITLE
Fix incomplete result fetching

### DIFF
--- a/clever/average_num_students_per_section.py
+++ b/clever/average_num_students_per_section.py
@@ -28,11 +28,15 @@ class average_num_students:
 				self.num_of_students += len(data["data"]["students"])
 				self.num_of_sections += 1
 			
-			links_rel_second = json_response["links"][1]["rel"]
-			
-			if links_rel_second == "next":
-				self.rel_uri = json_response["links"][1]["uri"]
-			else:
+			links = json_response["links"]
+
+			self.rel_uri = None
+			for link in links:
+				if link["rel"] == "next":
+					self.rel_uri = link["uri"]
+					break
+
+			if self.rel_uri == None:
 				break
 
 if __name__ == "__main__":


### PR DESCRIPTION
We may need to request multiple times to gather results and the information to link to the next result uri is an **array**, so that we can't rely on absolute position since each time it may change.

**For example, the first time:** _next_ is the 2nd element in the array 
```
"links": [
    {
      "rel": "self",
      "uri": "/v1.1/sections"
    },
    {
      "rel": "next",
      "uri": "/v1.1/sections?starting_after=530e597a049e75a9262d0b55"
    }
  ]
```

**The second time:** _next_ is the 3rd element in the array rather than the first one
```
"links": [
    {
      "rel": "self",
      "uri": "/v1.1/sections?starting_after=530e597a049e75a9262d0b55"
    },
    {
      "rel": "prev",
      "uri": "/v1.1/sections?ending_before=530e597a049e75a9262d0b56"
    },
    {
      "rel": "next",
      "uri": "/v1.1/sections?starting_after=530e597a049e75a9262d0bb9"
    }
  ]
```